### PR TITLE
Updates to support changes in twas docker images

### DIFF
--- a/lab4/CreatePreConfiguredtWASContainer/Dockerfile
+++ b/lab4/CreatePreConfiguredtWASContainer/Dockerfile
@@ -1,8 +1,8 @@
-FROM ibmcom/websphere-traditional:profile
+FROM ibmcom/websphere-traditional:latest
 
 USER root
 
-RUN mkdir /demo && chown was:was /demo
+RUN mkdir /demo && chown was /demo
 
 USER was
 RUN mkdir /demo/db2drivers

--- a/lab4/CreatePreConfiguredtWASContainer/wsadmin.py
+++ b/lab4/CreatePreConfiguredtWASContainer/wsadmin.py
@@ -4,8 +4,8 @@ AdminTask.createAuthDataEntry('[-alias PlantsAuthAlias -user db2inst1 -password 
 DB2JDBC=AdminTask.createJDBCProvider('[-scope Cell=DefaultCell01 -databaseType DB2 -providerType "DB2 Universal JDBC Driver Provider" -implementationType "Connection pool data source" -name "DB2 Universal JDBC Driver Provider" -classpath [/demo/db2drivers/db2jcc.jar /demo/db2drivers/db2jcc_license_cu.jar ] -nativePath [${DB2UNIVERSAL_JDBC_DRIVER_NATIVEPATH} ] ]')
 DB2JDBCXA=AdminTask.createJDBCProvider('[-scope Cell=DefaultCell01 -databaseType DB2 -providerType "DB2 Universal JDBC Driver Provider" -implementationType "XA data source" -name "DB2 Universal JDBC Driver Provider (XA)" -classpath [/demo/db2drivers/db2jcc.jar /demo/db2drivers/db2jcc_license_cu.jar ] -nativePath [${DB2UNIVERSAL_JDBC_DRIVER_NATIVEPATH} ] ]')
 #Create Datasources
-AdminTask.createDatasource(DB2JDBCXA, '[-name PlantsByWebSphereDataSource -jndiName jdbc/PlantsByWebSphereDataSource -dataStoreHelperClassName com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper -containerManagedPersistence true -componentManagedAuthenticationAlias DefaultNode01/PlantsAuthAlias -xaRecoveryAuthAlias DefaultNode01/PlantsAuthAlias -configureResourceProperties [[databaseName java.lang.String PLANTSDB] [driverType java.lang.Integer 4] [serverName java.lang.String 169.62.108.167] [portNumber java.lang.Integer 30866]]]')
-AdminTask.createDatasource(DB2JDBC, '[-name PlantsByWebSphereDataSourceNONJTA -jndiName jdbc/PlantsByWebSphereDataSourceNONJTA -dataStoreHelperClassName com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper -containerManagedPersistence true -componentManagedAuthenticationAlias DefaultNode01/PlantsAuthAlias -configureResourceProperties [[databaseName java.lang.String PLANTSDB] [driverType java.lang.Integer 4] [serverName java.lang.String 169.62.108.167] [portNumber java.lang.Integer 30866]]]')
+AdminTask.createDatasource(DB2JDBCXA, '[-name PlantsByWebSphereDataSource -jndiName jdbc/PlantsByWebSphereDataSource -dataStoreHelperClassName com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper -containerManagedPersistence true -componentManagedAuthenticationAlias DefaultNode01/PlantsAuthAlias -xaRecoveryAuthAlias DefaultNode01/PlantsAuthAlias -configureResourceProperties [[databaseName java.lang.String PLANTSDB] [driverType java.lang.Integer 4] [serverName java.lang.String 169.62.104.36] [portNumber java.lang.Integer 32612]]]')
+AdminTask.createDatasource(DB2JDBC, '[-name PlantsByWebSphereDataSourceNONJTA -jndiName jdbc/PlantsByWebSphereDataSourceNONJTA -dataStoreHelperClassName com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper -containerManagedPersistence true -componentManagedAuthenticationAlias DefaultNode01/PlantsAuthAlias -configureResourceProperties [[databaseName java.lang.String PLANTSDB] [driverType java.lang.Integer 4] [serverName java.lang.String 169.62.104.36] [portNumber java.lang.Integer 32612]]]')
 #Change JPA from 2.1 to 2.0
 svr = AdminConfig.getid('/Server:server1/')
 AdminTask.modifyJPASpecLevel(svr, '[ -specLevel 2.0]')
@@ -14,7 +14,7 @@ AdminApp.install('/demo/HelloWorld.war', '[ -appname HelloWorld -contextroot /He
 #AdminApp.install('/demo/pbw-ear7.ear', '[ -appname PlantsByWebSphere7 -contextroot /PlantsByWebSphere7]')
 AdminApp.install('/demo/pbw-ear8.ear', '[ -appname PlantsByWebSphere8 -contextroot /PlantsByWebSphere8]')
 #Uninstall default WAS applications
-AdminApp.uninstall('DefaultApplication')
+#AdminApp.uninstall('DefaultApplication')
 AdminApp.uninstall('query')
-AdminApp.uninstall('ivtApp')
+#AdminApp.uninstall('ivtApp')
 AdminConfig.save()


### PR DESCRIPTION
There were changes in the available traditional WAS docker images.  No profile tag is currently available and changed to use the latest tag instead.
When using the latest tag, then had to make the following changes to enable the Plants image to build successfully:
1) change base image in Dockerfile to use latest
2) change chown command in Dockerfile since was group no longer available in base image
3) change wsadmin.py to remove references to applications no longer in base image for ivtApp and Default app